### PR TITLE
Curried by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function decodeString<T>(decoder: Decoder<T>, input?: string) {
 export function decodeValue<T>(decoder: Decoder<T>): (input: any) => T;
 export function decodeValue<T>(decoder: Decoder<T>, input: any): T;
 export function decodeValue<T>(decoder: Decoder<T>, input?: any) {
-  if (typeof input !== "undefined") {
+  if (arguments.length === 2) {
     return decoder(input);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,34 @@ export * from "./safeDecoders";
 export * from "./shared";
 export * from "./unsafeDecoders";
 
-export const decodeString = <T>(decoder: Decoder<T>) => (input: string): T => {
-  let json: any;
+export function decodeString<T>(decoder: Decoder<T>): (input: string) => T;
+export function decodeString<T>(decoder: Decoder<T>, input: string): T;
+export function decodeString<T>(decoder: Decoder<T>, input?: string) {
+  const decode = (input: string) => {
+    let json: unknown;
 
-  try {
-    json = JSON.parse(input);
-  } catch {
-    throw new Error(`Could not parse input: ${input}`);
+    try {
+      json = JSON.parse(input);
+    } catch {
+      throw new Error(`Could not parse input: ${input}`);
+    }
+
+    return decoder(json);
+  };
+
+  if (typeof input !== "undefined") {
+    return decode(input);
   }
 
-  return decoder(json);
-};
+  return decode;
+}
 
-export const decodeValue = <T>(decoder: Decoder<T>) => (input: any): T =>
-  decoder(input);
+export function decodeValue<T>(decoder: Decoder<T>): (input: any) => T;
+export function decodeValue<T>(decoder: Decoder<T>, input: any): T;
+export function decodeValue<T>(decoder: Decoder<T>, input?: any) {
+  if (typeof input !== "undefined") {
+    return decoder(input);
+  }
+
+  return decoder;
+}

--- a/tests/safeDecoders.spec.ts
+++ b/tests/safeDecoders.spec.ts
@@ -20,45 +20,66 @@ describe("Safe decoders", () => {
     describe("str", () => {
       it("should parse strings and reject other values", () => {
         expect(decodeString(str)('"foo"')).toEqual("foo");
+        expect(decodeString(str, '"foo"')).toEqual("foo");
 
         expect(() => decodeString(str)("foo")).toThrow(Error);
         expect(() => decodeString(str)("42")).toThrow(Error);
         expect(() => decodeString(str)("true")).toThrow(Error);
         expect(() => decodeString(str)('["foo"]')).toThrow(Error);
         expect(() => decodeString(str)("null")).toThrow(Error);
+        expect(() => decodeString(str, "foo")).toThrow(Error);
+        expect(() => decodeString(str, "42")).toThrow(Error);
+        expect(() => decodeString(str, "true")).toThrow(Error);
+        expect(() => decodeString(str, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(str, "null")).toThrow(Error);
       });
     });
 
     describe("num", () => {
       it("should parse numbers and reject other values", () => {
         expect(decodeString(num)("42")).toEqual(42);
+        expect(decodeString(num, "42")).toEqual(42);
 
         expect(() => decodeString(num)('"foo"')).toThrow(Error);
         expect(() => decodeString(num)("true")).toThrow(Error);
         expect(() => decodeString(num)('["foo"]')).toThrow(Error);
         expect(() => decodeString(str)("null")).toThrow(Error);
+        expect(() => decodeString(num, '"foo"')).toThrow(Error);
+        expect(() => decodeString(num, "true")).toThrow(Error);
+        expect(() => decodeString(num, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(str, "null")).toThrow(Error);
       });
     });
 
     describe("bool", () => {
       it("should parse booleans and reject other values", () => {
         expect(decodeString(bool)("true")).toEqual(true);
+        expect(decodeString(bool, "true")).toEqual(true);
 
         expect(() => decodeString(bool)('"foo"')).toThrow(Error);
         expect(() => decodeString(bool)("42")).toThrow(Error);
         expect(() => decodeString(bool)('["foo"]')).toThrow(Error);
         expect(() => decodeString(str)("null")).toThrow(Error);
+        expect(() => decodeString(bool, '"foo"')).toThrow(Error);
+        expect(() => decodeString(bool, "42")).toThrow(Error);
+        expect(() => decodeString(bool, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(str, "null")).toThrow(Error);
       });
     });
 
     describe("nil", () => {
       it("should parse nulls and reject other values", () => {
         expect(decodeString(nil)("null")).toEqual(null);
+        expect(decodeString(nil, "null")).toEqual(null);
 
         expect(() => decodeString(nil)("true")).toThrow(Error);
         expect(() => decodeString(nil)('"foo"')).toThrow(Error);
         expect(() => decodeString(nil)("42")).toThrow(Error);
         expect(() => decodeString(nil)('["foo"]')).toThrow(Error);
+        expect(() => decodeString(nil, "true")).toThrow(Error);
+        expect(() => decodeString(nil, '"foo"')).toThrow(Error);
+        expect(() => decodeString(nil, "42")).toThrow(Error);
+        expect(() => decodeString(nil, '["foo"]')).toThrow(Error);
       });
     });
 
@@ -66,6 +87,11 @@ describe("Safe decoders", () => {
       it("should parse shallow arrays and reject malformed ones", () => {
         expect(decodeString(array(str))("[]")).toEqual([]);
         expect(decodeString(array(str))('["foo", "bar"]')).toEqual([
+          "foo",
+          "bar",
+        ]);
+        expect(decodeString(array(str), "[]")).toEqual([]);
+        expect(decodeString(array(str), '["foo", "bar"]')).toEqual([
           "foo",
           "bar",
         ]);
@@ -77,6 +103,13 @@ describe("Safe decoders", () => {
         expect(() => decodeString(array(str))('["foo", "bar", true]')).toThrow(
           Error,
         );
+        expect(() => decodeString(array(str), "[null]")).toThrow(Error);
+        expect(() => decodeString(array(str), '["foo", "bar", 42]')).toThrow(
+          Error,
+        );
+        expect(() => decodeString(array(str), '["foo", "bar", true]')).toThrow(
+          Error,
+        );
       });
 
       it("should parse deep arrays and reject malformed ones", () => {
@@ -86,12 +119,24 @@ describe("Safe decoders", () => {
           [42],
           [43],
         ]);
+        expect(decodeString(array(array(num)), "[]")).toEqual([]);
+        expect(decodeString(array(array(num)), "[[]]")).toEqual([[]]);
+        expect(decodeString(array(array(num)), "[[42], [43]]")).toEqual([
+          [42],
+          [43],
+        ]);
 
         expect(() => decodeString(array(array(num)))("[42, 43]")).toThrow(
           Error,
         );
         expect(() =>
           decodeString(array(array(num)))('[["foo"], ["bar"]]'),
+        ).toThrow(Error);
+        expect(() => decodeString(array(array(num)), "[42, 43]")).toThrow(
+          Error,
+        );
+        expect(() =>
+          decodeString(array(array(num)), '[["foo"], ["bar"]]'),
         ).toThrow(Error);
       });
     });
@@ -104,9 +149,15 @@ describe("Safe decoders", () => {
         expect(decodeString(decoder)('{ "foo": "foo" }')).toEqual({
           foo: "foo",
         });
+        expect(decodeString(decoder, "{}")).toEqual({});
+        expect(decodeString(decoder, '{ "foo": "foo" }')).toEqual({
+          foo: "foo",
+        });
 
         expect(() => decodeString(maybe(str))("null")).toThrow(Error);
         expect(() => decodeString(maybe(str))("42")).toThrow(Error);
+        expect(() => decodeString(maybe(str), "null")).toThrow(Error);
+        expect(() => decodeString(maybe(str), "42")).toThrow(Error);
       });
     });
 
@@ -114,9 +165,13 @@ describe("Safe decoders", () => {
       it("should parse null values and the provided decoder and reject the others", () => {
         expect(decodeString(nullable(str))("null")).toEqual(null);
         expect(decodeString(nullable(str))('"foo"')).toEqual("foo");
+        expect(decodeString(nullable(str), "null")).toEqual(null);
+        expect(decodeString(nullable(str), '"foo"')).toEqual("foo");
 
         expect(() => decodeString(nullable(str))("undefined")).toThrow(Error);
         expect(() => decodeString(nullable(str))("42")).toThrow(Error);
+        expect(() => decodeString(nullable(str), "undefined")).toThrow(Error);
+        expect(() => decodeString(nullable(str), "42")).toThrow(Error);
       });
     });
 
@@ -126,10 +181,15 @@ describe("Safe decoders", () => {
 
         expect(decodeString(decoder)("42")).toEqual(42);
         expect(decodeString(decoder)('"foo"')).toEqual("foo");
+        expect(decodeString(decoder, "42")).toEqual(42);
+        expect(decodeString(decoder, '"foo"')).toEqual("foo");
 
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
         expect(() => decodeString(decoder)("[]")).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
+        expect(() => decodeString(decoder, "[]")).toThrow(Error);
       });
 
       it("should parse with only one of the three given decoders and reject the other ones", () => {
@@ -139,10 +199,17 @@ describe("Safe decoders", () => {
         expect(decodeString(decoder)('"foo"')).toEqual("foo");
         expect(decodeString(decoder)("[]")).toEqual([]);
         expect(decodeString(decoder)("[true]")).toEqual([true]);
+        expect(decodeString(decoder, "42")).toEqual(42);
+        expect(decodeString(decoder, '"foo"')).toEqual("foo");
+        expect(decodeString(decoder, "[]")).toEqual([]);
+        expect(decodeString(decoder, "[true]")).toEqual([true]);
 
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
         expect(() => decodeString(decoder)("[42, 43]")).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
+        expect(() => decodeString(decoder, "[42, 43]")).toThrow(Error);
       });
     });
 
@@ -154,8 +221,10 @@ describe("Safe decoders", () => {
         );
 
         expect(decodeString(decoder)('"foo"')).toEqual("foo");
+        expect(decodeString(decoder, '"foo"')).toEqual("foo");
 
-        expect(() => decodeString(decoder)("42")).toThrow(Error);
+        expect(decodeString(decoder)('"foo"')).toEqual("foo");
+        expect(decodeString(decoder, '"foo"')).toEqual("foo");
       });
 
       it("should throw even if only one decoder fails", () => {
@@ -168,6 +237,7 @@ describe("Safe decoders", () => {
         );
 
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
       });
 
       it("should handle as many decoders as needed (up to 10)", () => {
@@ -178,8 +248,12 @@ describe("Safe decoders", () => {
         );
 
         expect(decodeString(decoder)("null")).toEqual(null);
+        expect(decodeString(decoder, "null")).toEqual(null);
+
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
         expect(() => decodeString(decoder)("42")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
       });
 
       it("should support recursion", () => {
@@ -192,6 +266,7 @@ describe("Safe decoders", () => {
         );
 
         expect(decodeString(decoder)("null")).toEqual(null);
+        expect(decodeString(decoder, "null")).toEqual(null);
       });
 
       it("should allow decoder sequencing", () => {
@@ -219,6 +294,15 @@ describe("Safe decoders", () => {
           name: "foobar",
           phoneNumber: "090-0808-9878",
         });
+        expect(
+          decodeString(
+            decoder,
+            '{"center": "0808", "left": "090", "name": "foobar", "right": "9878"}',
+          ),
+        ).toEqual({
+          name: "foobar",
+          phoneNumber: "090-0808-9878",
+        });
       });
     });
 
@@ -227,23 +311,29 @@ describe("Safe decoders", () => {
         const decoder = map(({ length }) => length, str);
 
         expect(decodeString(decoder)('"foo"')).toEqual(3);
+        expect(decodeString(decoder, '"foo"')).toEqual(3);
 
         expect(() => decodeString(decoder)("42")).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
       });
 
       it("should handle several decoders", () => {
         const decoder = map(() => 1, str, str, str, str, str);
 
         expect(decodeString(decoder)('"foo"')).toEqual(1);
+        expect(decodeString(decoder, '"foo"')).toEqual(1);
 
         expect(() => decodeString(decoder)("42")).toThrow(Error);
         expect(() => decodeString(decoder)("true")).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
       });
 
       it("should throw even if only one decoder fails", () => {
         const decoder = map(() => null, str, str, str, str, num);
 
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
       });
 
       it("should handle as many decoders as needed (up to 10)", () => {
@@ -259,9 +349,16 @@ describe("Safe decoders", () => {
           y: null,
           z: null,
         });
+        expect(decodeString(decoder, "null")).toEqual({
+          x: null,
+          y: null,
+          z: null,
+        });
 
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
         expect(() => decodeString(decoder)("42")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
       });
 
       it("should support recursion", () => {
@@ -271,6 +368,7 @@ describe("Safe decoders", () => {
         );
 
         expect(decodeString(decoder)('"foo"')).toEqual({ x: 6 });
+        expect(decodeString(decoder, '"foo"')).toEqual({ x: 6 });
       });
     });
 
@@ -279,20 +377,30 @@ describe("Safe decoders", () => {
         const decoder = field("x", num);
 
         expect(decodeString(decoder)('{ "x": 42 }')).toEqual(42);
+        expect(decodeString(decoder, '{ "x": 42 }')).toEqual(42);
 
         expect(() => decodeString(decoder)('{ "x": "foo" }')).toThrow(Error);
         expect(() => decodeString(decoder)('{ "y": 42 }')).toThrow(Error);
+        expect(() => decodeString(decoder, '{ "x": "foo" }')).toThrow(Error);
+        expect(() => decodeString(decoder, '{ "y": 42 }')).toThrow(Error);
       });
 
       it("should support recursion", () => {
         const decoder = field("x", field("y", num));
 
         expect(decodeString(decoder)('{ "x": { "y": 42 } }')).toEqual(42);
+        expect(decodeString(decoder, '{ "x": { "y": 42 } }')).toEqual(42);
 
         expect(() => decodeString(decoder)('{ "x": { "y": "foo" } }')).toThrow(
           Error,
         );
         expect(() => decodeString(decoder)('{ "y": { "x": 42 } }')).toThrow(
+          Error,
+        );
+        expect(() => decodeString(decoder, '{ "x": { "y": "foo" } }')).toThrow(
+          Error,
+        );
+        expect(() => decodeString(decoder, '{ "y": { "x": 42 } }')).toThrow(
           Error,
         );
       });
@@ -304,9 +412,15 @@ describe("Safe decoders", () => {
 
         expect(decodeString(decoder)('"foo"')).toEqual("foo");
         expect(decodeString(decoder)('"bar"')).toEqual("bar");
+        expect(decodeString(decoder, '"foo"')).toEqual("foo");
+        expect(decodeString(decoder, '"bar"')).toEqual("bar");
+
         expect(() => decodeString(decoder)('"foobar"')).toThrow(Error);
         expect(() => decodeString(decoder)("42")).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foobar"')).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
 
       it("should parse a simple union of ten simple values", () => {
@@ -325,10 +439,23 @@ describe("Safe decoders", () => {
         expect(decodeString(decoder)("20")).toEqual(20);
         expect(decodeString(decoder)("40")).toEqual(40);
         expect(decodeString(decoder)("100")).toEqual(100);
+        expect(decodeString(decoder, "0")).toEqual(0);
+        expect(decodeString(decoder, "1")).toEqual(1);
+        expect(decodeString(decoder, "2")).toEqual(2);
+        expect(decodeString(decoder, "3")).toEqual(3);
+        expect(decodeString(decoder, "5")).toEqual(5);
+        expect(decodeString(decoder, "8")).toEqual(8);
+        expect(decodeString(decoder, "13")).toEqual(13);
+        expect(decodeString(decoder, "20")).toEqual(20);
+        expect(decodeString(decoder, "40")).toEqual(40);
+        expect(decodeString(decoder, "100")).toEqual(100);
 
         expect(() => decodeString(decoder)("42")).toThrow(Error);
         expect(() => decodeString(decoder)('"foobar"')).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foobar"')).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
     });
 
@@ -359,8 +486,10 @@ describe("Safe decoders", () => {
         const expected = { foo: "bar", bar: 42, baz: [true, false] };
 
         expect(decodeString(decoder)(input)).toEqual(expected);
+        expect(decodeString(decoder, input)).toEqual(expected);
 
         expect(() => decodeString(decoder)(wrongInput)).toThrow(Error);
+        expect(() => decodeString(decoder, wrongInput)).toThrow(Error);
       });
 
       it("should parse a simple object according to the given decoders and allow extra attributes", () => {
@@ -393,8 +522,10 @@ describe("Safe decoders", () => {
         const expected = { foo: "bar", bar: 42, baz: [true, false], qux: true };
 
         expect(decodeString(decoder)(input)).toEqual(expected);
+        expect(decodeString(decoder, input)).toEqual(expected);
 
         expect(() => decodeString(decoder)(wrongInput)).toThrow(Error);
+        expect(() => decodeString(decoder, wrongInput)).toThrow(Error);
       });
 
       it("should parse a complex object according to the given decoders", () => {
@@ -424,9 +555,8 @@ describe("Safe decoders", () => {
           baz: [true, false],
         };
 
-        const received = decodeString(decoder)(input);
-
-        expect(received).toEqual(expected);
+        expect(decodeString(decoder)(input)).toEqual(expected);
+        expect(decodeString(decoder, input)).toEqual(expected);
       });
     });
 
@@ -513,9 +643,8 @@ describe("Safe decoders", () => {
           null,
         ];
 
-        const received = decodeString(decoder)(input);
-
-        expect(received).toEqual(expected);
+        expect(decodeString(decoder)(input)).toEqual(expected);
+        expect(decodeString(decoder, input)).toEqual(expected);
       });
     });
   });
@@ -569,9 +698,9 @@ describe("Safe decoders", () => {
           null,
         ];
 
-        const received = decodeValue(decoder)(input);
+        expect(decodeValue(decoder, input)).toEqual(input);
 
-        expect(received).toEqual(input);
+        expect(() => decodeValue(decoder, undefined)).toThrow(Error);
       });
     });
   });

--- a/tests/unsafeDecoders.spec.ts
+++ b/tests/unsafeDecoders.spec.ts
@@ -17,24 +17,36 @@ describe("Unsafe decoders", () => {
         const decoder = format(/^[\w\d]+\@[\w\d]+\.\w{2,4}$/);
 
         expect(decodeString(decoder)('"foo@bar.com"')).toEqual("foo@bar.com");
+        expect(decodeString(decoder, '"foo@bar.com"')).toEqual("foo@bar.com");
 
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
         expect(() => decodeString(decoder)("42")).toThrow(Error);
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "42")).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
     });
 
     describe("notEmpty", () => {
       it("should parse non empty and reject other values", () => {
         expect(decodeString(notEmpty)('"foo"')).toEqual("foo");
+        expect(decodeString(notEmpty, '"foo"')).toEqual("foo");
 
         expect(() => decodeString(notEmpty)('""')).toThrow(Error);
         expect(() => decodeString(notEmpty)("42")).toThrow(Error);
         expect(() => decodeString(notEmpty)("true")).toThrow(Error);
         expect(() => decodeString(notEmpty)('["foo"]')).toThrow(Error);
         expect(() => decodeString(notEmpty)("null")).toThrow(Error);
+        expect(() => decodeString(notEmpty, '""')).toThrow(Error);
+        expect(() => decodeString(notEmpty, "42")).toThrow(Error);
+        expect(() => decodeString(notEmpty, "true")).toThrow(Error);
+        expect(() => decodeString(notEmpty, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(notEmpty, "null")).toThrow(Error);
       });
     });
 
@@ -44,6 +56,8 @@ describe("Unsafe decoders", () => {
 
         expect(decodeString(decoder)("9")).toEqual(9);
         expect(decodeString(decoder)("63")).toEqual(63);
+        expect(decodeString(decoder, "9")).toEqual(9);
+        expect(decodeString(decoder, "63")).toEqual(63);
 
         expect(() => decodeString(decoder)("8")).toThrow(Error);
         expect(() => decodeString(decoder)("64")).toThrow(Error);
@@ -51,6 +65,12 @@ describe("Unsafe decoders", () => {
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, "8")).toThrow(Error);
+        expect(() => decodeString(decoder, "64")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
     });
 
@@ -60,12 +80,19 @@ describe("Unsafe decoders", () => {
 
         expect(decodeString(decoder)("9")).toEqual(9);
         expect(decodeString(decoder)("10000")).toEqual(10000);
+        expect(decodeString(decoder, "9")).toEqual(9);
+        expect(decodeString(decoder, "10000")).toEqual(10000);
 
         expect(() => decodeString(decoder)("8")).toThrow(Error);
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, "8")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
     });
 
@@ -75,12 +102,19 @@ describe("Unsafe decoders", () => {
 
         expect(decodeString(decoder)("63")).toEqual(63);
         expect(decodeString(decoder)("-10000")).toEqual(-10000);
+        expect(decodeString(decoder, "63")).toEqual(63);
+        expect(decodeString(decoder, "-10000")).toEqual(-10000);
 
         expect(() => decodeString(decoder)("64")).toThrow(Error);
         expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
         expect(() => decodeString(decoder)("true")).toThrow(Error);
         expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
         expect(() => decodeString(decoder)("null")).toThrow(Error);
+        expect(() => decodeString(decoder, "64")).toThrow(Error);
+        expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+        expect(() => decodeString(decoder, "true")).toThrow(Error);
+        expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+        expect(() => decodeString(decoder, "null")).toThrow(Error);
       });
     });
   });
@@ -90,6 +124,7 @@ describe("Unsafe decoders", () => {
       const decoder = lengthWithin(2, 4);
 
       expect(decodeString(decoder)('"foo"')).toEqual("foo");
+      expect(decodeString(decoder, '"foo"')).toEqual("foo");
 
       expect(() => decodeString(decoder)('""')).toThrow(Error);
       expect(() => decodeString(decoder)('"fo"')).toThrow(Error);
@@ -99,6 +134,14 @@ describe("Unsafe decoders", () => {
       expect(() => decodeString(decoder)("true")).toThrow(Error);
       expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
       expect(() => decodeString(decoder)("null")).toThrow(Error);
+      expect(() => decodeString(decoder, '""')).toThrow(Error);
+      expect(() => decodeString(decoder, '"fo"')).toThrow(Error);
+      expect(() => decodeString(decoder, '"fooo"')).toThrow(Error);
+      expect(() => decodeString(decoder, '"super foobar"')).toThrow(Error);
+      expect(() => decodeString(decoder, "8")).toThrow(Error);
+      expect(() => decodeString(decoder, "true")).toThrow(Error);
+      expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+      expect(() => decodeString(decoder, "null")).toThrow(Error);
     });
   });
 
@@ -107,12 +150,18 @@ describe("Unsafe decoders", () => {
       const decoder = minLength(3);
 
       expect(decodeString(decoder)('"fooo"')).toEqual("fooo");
+      expect(decodeString(decoder, '"fooo"')).toEqual("fooo");
 
       expect(() => decodeString(decoder)("8")).toThrow(Error);
       expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
       expect(() => decodeString(decoder)("true")).toThrow(Error);
       expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
       expect(() => decodeString(decoder)("null")).toThrow(Error);
+      expect(() => decodeString(decoder, "8")).toThrow(Error);
+      expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+      expect(() => decodeString(decoder, "true")).toThrow(Error);
+      expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+      expect(() => decodeString(decoder, "null")).toThrow(Error);
     });
   });
 
@@ -121,12 +170,18 @@ describe("Unsafe decoders", () => {
       const decoder = maxLength(3);
 
       expect(decodeString(decoder)('"fo"')).toEqual("fo");
+      expect(decodeString(decoder, '"fo"')).toEqual("fo");
 
       expect(() => decodeString(decoder)("8")).toThrow(Error);
       expect(() => decodeString(decoder)('"foo"')).toThrow(Error);
       expect(() => decodeString(decoder)("true")).toThrow(Error);
       expect(() => decodeString(decoder)('["foo"]')).toThrow(Error);
       expect(() => decodeString(decoder)("null")).toThrow(Error);
+      expect(() => decodeString(decoder, "8")).toThrow(Error);
+      expect(() => decodeString(decoder, '"foo"')).toThrow(Error);
+      expect(() => decodeString(decoder, "true")).toThrow(Error);
+      expect(() => decodeString(decoder, '["foo"]')).toThrow(Error);
+      expect(() => decodeString(decoder, "null")).toThrow(Error);
     });
   });
 });


### PR DESCRIPTION
This Pull Request allows the two notations:

```TypeScript
const value1 = decodeString(str)('"foo"');
const value2 = decodeString(str, '"foo"');
```

and

```TypeScript
const value1 = decodeValue(str)('foo');
const value2 = decodeValue(str, 'foo');
```