### PR TITLE
Map is now properly typed thanks to TS 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5015,9 +5015,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.1.0-rc.20180911",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.0-rc.20180911.tgz",
+      "integrity": "sha512-q6WeNUmkB6GNKftShDNLr9/aBSCVEFQ+8PF9/DwF/EswfCj1l6BmxtDU8s8eFlmgOmwOqBLaYdut6BEjvnzYVg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "@types/jest": "^23.1.4",
     "jest": "^23.3.0",
     "ts-jest": "^23.0.0",
-    "typescript": "^3.0.1"
+    "typescript": "^3.1.0-rc.20180911"
   }
 }

--- a/src/safeDecoders.ts
+++ b/src/safeDecoders.ts
@@ -11,11 +11,12 @@ export type Composeable = <Decoders extends Array<Decoder<any>>>(
 ) => Decoder<Decoders[number] extends Decoder<infer T> ? T : never>;
 
 export type Map = <Decoders extends Array<Decoder<any>>, T>(
-  // TypeScript is not able to fully understand the types of values yet.
-  // For example a in a decoder like `map((a, b) => ..., str, num);`,
-  // `a` and `b` will have type `string | number` except of `a` being `string` and `b` being `number`
   f: (
-    ...values: Array<Decoders[number] extends Decoder<infer U> ? U : never>
+    ...values: {
+      [key in keyof Decoders]: Decoders[key] extends Decoder<infer U>
+        ? U
+        : never
+    }
   ) => T,
   ...decoders: Decoders
 ) => Decoder<T>;
@@ -174,6 +175,6 @@ export const compose: Composeable = (...decoders: Array<Decoder<any>>) => (
 ) => decoders.reduce((acc, reducer) => reducer(acc), value);
 
 export const map: Map = (
-  f: (...values: Array<any>) => any,
+  f: (...values: any) => any,
   ...decoders: Array<Decoder<any>>
 ) => (value: any) => f(...decoders.map(decoder => decoder(value)));

--- a/tests/safeDecoders.spec.ts
+++ b/tests/safeDecoders.spec.ts
@@ -245,7 +245,7 @@ describe("Safe decoders", () => {
         expect(() => decodeString(decoder, '"foo"')).toThrow(DecodeError);
       });
 
-      it("should handle as many decoders as needed (up to 10)", () => {
+      it("should handle as many decoders as needed", () => {
         const decoder = compose(
           nil,
           nullable(str),
@@ -341,7 +341,7 @@ describe("Safe decoders", () => {
         expect(() => decodeString(decoder, '"foo"')).toThrow(DecodeError);
       });
 
-      it("should handle as many decoders as needed (up to 10)", () => {
+      it("should handle as many decoders as needed", () => {
         const decoder = map(
           (x, y, z) => ({ x, y, z }),
           nil,


### PR DESCRIPTION
Waiting for a proper release of TS 3.1 https://github.com/Microsoft/TypeScript/releases

Also, we need to support TS <3.1 using https://github.com/Microsoft/TypeScript/issues/22605 bringing back the old typings for backward compatibility.