### PR TITLE
Allow transformers (like map) in the object decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Added
+
+- New `record` decoder
+
+### Changed
+
+- Performance: Objects are now duplicated when using the `object` and `record` decoders
+- Breaking: `object` filters out the unowned properties
+
+### Fixed
+
+- `map` (and all the "transformers") can be used with `object` or `record`
+
 ## [0.5.0] - 2019-07-02
 
 ### Changed

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -34,14 +34,23 @@ export class ParseError extends Error {
   }
 }
 
-export function getAccurateTypeOf(x: any): string {
-  const rawType: string = Object.prototype.toString.call(x);
+export function getAccurateTypeOf(value: any): string {
+  const rawType: string = Object.prototype.toString.call(value);
 
   const matches = rawType.toLowerCase().match(/(\w+)/g);
 
   if (!matches || matches.length < 2) {
-    return typeof x;
+    return typeof value;
   }
 
   return matches[1];
+}
+
+// "Safe" alternative to the hasOwnProperty method
+export function hasOwnProperty(value: any, key: string): boolean {
+  try {
+    return Object.prototype.hasOwnProperty.call(value, key);
+  } catch {
+    return false;
+  }
 }

--- a/tests/safeDecoders.spec.ts
+++ b/tests/safeDecoders.spec.ts
@@ -612,6 +612,28 @@ describe("Safe decoders", () => {
         expect(decodeString(decoder)(input)).toEqual(expected);
         expect(decodeString(decoder, input)).toEqual(expected);
       });
+
+      it("should support transformers (like map)", () => {
+        const decoder = object({
+          foo: map(({ length }) => length, str),
+          bar: str,
+        });
+
+        const input = `
+          {
+            "foo": "bar",
+            "bar": "baz"
+          }
+        `;
+
+        const expected = {
+          foo: 3,
+          bar: "baz",
+        };
+
+        expect(decodeString(decoder)(input)).toEqual(expected);
+        expect(decodeString(decoder, input)).toEqual(expected);
+      });
     });
 
     describe("record", () => {
@@ -697,7 +719,7 @@ describe("Safe decoders", () => {
         expect(decodeString(decoder, input)).toEqual(expected);
       });
 
-      it("should support decoder which modify the value (like map)", () => {
+      it("should support transformers (like map)", () => {
         const decoder = record(map(({ length }) => length, str));
 
         const input = `


### PR DESCRIPTION
This:

```ts
const decoder = object({
  foo: map(({ length }) => length, str),
  bar: str,
});
```

on this kind of input:
```json
{
  "foo": "bar",
  "bar": "baz"
}
```

used to return:

```ts
{
  foo: "bar",
  bar: "baz",
};
```

It now properly returns:

```ts
{
  foo: 3,
  bar: "baz",
};
```